### PR TITLE
[0.99] Navbar fixes in event&contentpage

### DIFF
--- a/reader/src/ASTRv2/contentpage.vue
+++ b/reader/src/ASTRv2/contentpage.vue
@@ -2,7 +2,7 @@
     <n-layout>
         
         <n-layout-content class="content" ref="content">
-            <n-affix :top="30" :trigger-top="30" position="fixed">
+            <n-affix :top="0" :trigger-top="30" position="fixed">
             <n-skeleton v-if="loading" class="breadcrumb"></n-skeleton>
             <n-space justify="space-between" v-else item-style="display: flex;" align="center" class="breadcrumb">
                 <n-breadcrumb >


### PR DESCRIPTION
"trigger-top	number	undefined	The distance px to top of target to trigger top affix. (if not set, use top prop)"
"top	                number	undefined	The css top property after trigger top affix. (if not set, use trigger-top prop)"
(https://www.naiveui.com/en-US/dark/components/affix)
What could have happened here is that you specified only one and the other was set to the same value, which caused the issue. I modified the top value to reflect what i did on my console but i'm not sure if this will really work as intended as i have no proof of testing