### PR TITLE
Enable horizontal centering

### DIFF
--- a/reader/src/ASTRv2/content/img.vue
+++ b/reader/src/ASTRv2/content/img.vue
@@ -43,13 +43,13 @@ export default {
   max-width: 500px;
   max-height: 300px;
   /*horizontal center*/
-  margin-left: calc(100vh / 7 * 2);
+  /* margin-left: calc(100vh/7*2); */
 }
 
 .line .backgrounds img {
   margin: 10px;
   /*horizontal center*/
-  margin-left: calc(100vh / 7 * 2);
+  /* margin-left: calc(100vh/7*2); */
   height: 150px;
   width: 700px;
   object-fit: none !important;

--- a/reader/src/ASTRv2/content/img.vue
+++ b/reader/src/ASTRv2/content/img.vue
@@ -43,13 +43,13 @@ export default {
   max-width: 500px;
   max-height: 300px;
   /*horizontal center*/
-  /* margin-left: calc(100vh/7*2); */
+  margin-left: calc(100vh / 7 * 2);
 }
 
 .line .backgrounds img {
   margin: 10px;
   /*horizontal center*/
-  /* margin-left: calc(100vh/7*2); */
+  margin-left: calc(100vh / 7 * 2);
   height: 150px;
   width: 700px;
   object-fit: none !important;

--- a/reader/src/ASTRv2/content/img.vue
+++ b/reader/src/ASTRv2/content/img.vue
@@ -1,11 +1,13 @@
 <template>
-  <n-image
-    :class="{
-      images: imgtype == 'images' || bgMode == 'full',
-      backgrounds: imgtype == 'backgrounds' && bgMode == 'stripe',
-    }"
-    :src="getAvgUrl()"
-  />
+  <div class="image-container">
+    <n-image
+      :class="{
+        images: imgtype == 'images' || bgMode == 'full',
+        backgrounds: imgtype == 'backgrounds' && bgMode == 'stripe',
+      }"
+      :src="getAvgUrl()"
+    />
+  </div>
 </template>
 
 <script>
@@ -39,6 +41,15 @@ export default {
 </script>
 
 <style>
+.image-container {
+  text-align: center;
+}
+
+.image-container n-image {
+  display: block;
+  margin: 0 auto;
+}
+
 .line .images img {
   max-width: 500px;
   max-height: 300px;


### PR DESCRIPTION
Enabling images horizontally centered.

- before  
<img width="1440" alt="스크린샷 2024-10-04 오후 4 19 43" src="https://github.com/user-attachments/assets/026535bf-a23c-48d7-b3b1-9833feed49d2">

- after  
<img width="1440" alt="스크린샷 2024-10-04 오후 4 19 49" src="https://github.com/user-attachments/assets/ee442e9b-f938-497d-ad00-ba94f9709884">


Closes https://github.com/050644zf/ArknightsStoryTextReader/issues/62