### PR TITLE
feat: added specific width with logo image

### DIFF
--- a/reader/src/ASTRv2/header.vue
+++ b/reader/src/ASTRv2/header.vue
@@ -26,7 +26,7 @@
             <n-a :href="href" @click="navigate">
               <n-image
                 :src="ASTReader"
-                style="height: 30px"
+                style="width: 90.828px; height: 30px"
                 preview-disabled
                 class="astrtitle"
               />


### PR DESCRIPTION
firefox must give specific width on media files, I found out that the logo 'astrtitle' is just giving it's height. So I added width! 

- firefox 
![image](https://github.com/user-attachments/assets/a86de6d5-8831-4f11-8630-bdc021f30d88)

- chrome 

![image](https://github.com/user-attachments/assets/e13be3e4-e764-4b43-92d9-0ee8b3dbbdce)


Closes #68 