### PR TITLE
feat: remove margin: 5%

### DIFF
--- a/reader/src/ASTRv2/footer.vue
+++ b/reader/src/ASTRv2/footer.vue
@@ -99,7 +99,6 @@ export default {
 
 <style>
 .footer {
-  margin: 5%;
   margin-top: -30px;
   padding: 20px;
   padding-top: 80px;


### PR DESCRIPTION
I removed margin that caused white space underneath the footer only at firefox (plz... firefox... 😇 )
Was there any reason for this margin value? (since i couldn't find commit message or log for this one)

- before
<img width="1440" alt="스크린샷 2024-10-14 오전 8 31 47" src="https://github.com/user-attachments/assets/dbc7d1fb-8ed9-48fc-9760-c3bb5218bff3">

- after

<img width="1440" alt="스크린샷 2024-10-14 오전 8 41 42" src="https://github.com/user-attachments/assets/c99c02e4-3121-465b-99a4-d283d214df37">

closes #71 