### PR TITLE
Show invisible options and hide empty options

### DIFF
--- a/reader/src/ASTRv2/content/decision.vue
+++ b/reader/src/ASTRv2/content/decision.vue
@@ -1,17 +1,28 @@
 <template>
   <div :class="line.prop">
     <div
-      v-for="(option, index) in line.attributes.values.split(';')"
+      v-for="(option, index) in line.attributes.options.split(';')"
       :key="option"
       class="option"
-      @click="jumpTo(line.targetLine['option' + option])"
+      @click="
+        jumpTo(line.targetLine['option' + (
+            line.attributes.values.split(';')[index] || 
+            line.attributes.values.split(';').pop()
+          )])
+      "
       @mouseover="
-        addClass(line.targetLine['option' + option], 'PredicateFocused')
+        addClass(line.targetLine['option' + (
+            line.attributes.values.split(';')[index] || 
+            line.attributes.values.split(';').pop()
+          )], 'PredicateFocused')
       "
       @mouseout="
-        removeClass(line.targetLine['option' + option], 'PredicateFocused')
+        removeClass(line.targetLine['option' + (
+            line.attributes.values.split(';')[index] || 
+            line.attributes.values.split(';').pop()
+          )], 'PredicateFocused')
       "
-      v-html="parseContent(line.attributes.options.split(';')[index])"
+      v-html="parseContent(option)"
     ></div>
   </div>
 </template>


### PR DESCRIPTION
Removed empty content options  
Display 4 or more options  

I can't check this stories in the game.

### level_act25side_02_beg.json
ID: 639

Before  
![CW-2_Begin_639_1](https://github.com/user-attachments/assets/4740eedd-bf63-4fa3-8a64-55d09530311f)

After  
![CW-2_Begin_639_2](https://github.com/user-attachments/assets/22bb6e4b-e012-4d3b-b2b5-b633e7b6278c)

### story_ghost_2_1.json
ID: 642

Before  
![story_ghost_2_1 642_1](https://github.com/user-attachments/assets/1cec20ee-265b-4bce-91f3-9e0437d6b598)

After  
![story_ghost_2_1 642_2](https://github.com/user-attachments/assets/c9d38b8a-16bf-48fa-9653-3c17b02620de)
